### PR TITLE
Renaming state enums

### DIFF
--- a/src/events/terminal.rs
+++ b/src/events/terminal.rs
@@ -1,4 +1,4 @@
-use crate::state::{CurrentMenu, State};
+use crate::state::{Menu, State};
 use anyhow::Result;
 use crossterm::{
     event,
@@ -81,11 +81,11 @@ impl Handler {
                 } => {
                     debug!("Processing previous menu item event '{:?}'...", event);
                     match state.current_menu() {
-                        CurrentMenu::Status => (),
-                        CurrentMenu::Shortcuts => {
+                        Menu::Status => (),
+                        Menu::Shortcuts => {
                             state.previous_shortcut();
                         }
-                        CurrentMenu::TopList => (),
+                        Menu::TopList => (),
                     }
                 }
                 KeyEvent {
@@ -94,11 +94,11 @@ impl Handler {
                 } => {
                     debug!("Processing next menu item event '{:?}'...", event);
                     match state.current_menu() {
-                        CurrentMenu::Status => (),
-                        CurrentMenu::Shortcuts => {
+                        Menu::Status => (),
+                        Menu::Shortcuts => {
                             state.next_shortcut();
                         }
-                        CurrentMenu::TopList => (),
+                        Menu::TopList => (),
                     }
                 }
                 _ => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,19 +2,19 @@ use crate::asana::{User, Workspace};
 use crate::ui::SPINNER_FRAME_COUNT;
 use tui::layout::Rect;
 
-/// Tracks the currently-selected menu.
+/// Specifying the different menus.
 ///
 #[derive(Debug, PartialEq, Eq)]
-pub enum CurrentMenu {
+pub enum Menu {
     Status,
     Shortcuts,
     TopList,
 }
 
-/// Tracks the currently-selected shortcut.
+/// Specifying the different shortcuts.
 ///
 #[derive(Debug, PartialEq, Eq)]
-pub enum CurrentShortcut {
+pub enum Shortcut {
     MyTasks,
     DueSoon,
     PastDue,
@@ -31,8 +31,8 @@ pub struct State {
     active_workspace_gid: Option<String>,
     terminal_size: Rect,
     spinner_index: usize,
-    current_menu: CurrentMenu,
-    current_shortcut: CurrentShortcut,
+    current_menu: Menu,
+    current_shortcut: Shortcut,
 }
 
 /// Defines default application state.
@@ -45,8 +45,8 @@ impl Default for State {
             active_workspace_gid: None,
             terminal_size: Rect::default(),
             spinner_index: 0,
-            current_menu: CurrentMenu::Shortcuts,
-            current_shortcut: CurrentShortcut::MyTasks,
+            current_menu: Menu::Shortcuts,
+            current_shortcut: Shortcut::MyTasks,
         }
     }
 }
@@ -117,7 +117,7 @@ impl State {
 
     /// Return the current menu.
     ///
-    pub fn current_menu(&self) -> &CurrentMenu {
+    pub fn current_menu(&self) -> &Menu {
         &self.current_menu
     }
 
@@ -125,9 +125,9 @@ impl State {
     ///
     pub fn next_menu(&mut self) -> &mut Self {
         match self.current_menu {
-            CurrentMenu::Status => self.current_menu = CurrentMenu::Shortcuts,
-            CurrentMenu::Shortcuts => self.current_menu = CurrentMenu::TopList,
-            CurrentMenu::TopList => self.current_menu = CurrentMenu::Status,
+            Menu::Status => self.current_menu = Menu::Shortcuts,
+            Menu::Shortcuts => self.current_menu = Menu::TopList,
+            Menu::TopList => self.current_menu = Menu::Status,
         }
         self
     }
@@ -136,16 +136,16 @@ impl State {
     ///
     pub fn previous_menu(&mut self) -> &mut Self {
         match self.current_menu {
-            CurrentMenu::Status => self.current_menu = CurrentMenu::TopList,
-            CurrentMenu::Shortcuts => self.current_menu = CurrentMenu::Status,
-            CurrentMenu::TopList => self.current_menu = CurrentMenu::Shortcuts,
+            Menu::Status => self.current_menu = Menu::TopList,
+            Menu::Shortcuts => self.current_menu = Menu::Status,
+            Menu::TopList => self.current_menu = Menu::Shortcuts,
         }
         self
     }
 
     /// Return the current shortcut.
     ///
-    pub fn current_shortcut(&self) -> &CurrentShortcut {
+    pub fn current_shortcut(&self) -> &Shortcut {
         &self.current_shortcut
     }
 
@@ -153,16 +153,12 @@ impl State {
     ///
     pub fn next_shortcut(&mut self) -> &mut Self {
         match self.current_shortcut {
-            CurrentShortcut::MyTasks => self.current_shortcut = CurrentShortcut::DueSoon,
-            CurrentShortcut::DueSoon => self.current_shortcut = CurrentShortcut::PastDue,
-            CurrentShortcut::PastDue => self.current_shortcut = CurrentShortcut::RecentlyCreated,
-            CurrentShortcut::RecentlyCreated => {
-                self.current_shortcut = CurrentShortcut::RecentlyEdited
-            }
-            CurrentShortcut::RecentlyEdited => {
-                self.current_shortcut = CurrentShortcut::RecentlyCompleted
-            }
-            CurrentShortcut::RecentlyCompleted => self.current_shortcut = CurrentShortcut::MyTasks,
+            Shortcut::MyTasks => self.current_shortcut = Shortcut::DueSoon,
+            Shortcut::DueSoon => self.current_shortcut = Shortcut::PastDue,
+            Shortcut::PastDue => self.current_shortcut = Shortcut::RecentlyCreated,
+            Shortcut::RecentlyCreated => self.current_shortcut = Shortcut::RecentlyEdited,
+            Shortcut::RecentlyEdited => self.current_shortcut = Shortcut::RecentlyCompleted,
+            Shortcut::RecentlyCompleted => self.current_shortcut = Shortcut::MyTasks,
         }
         self
     }
@@ -171,16 +167,12 @@ impl State {
     ///
     pub fn previous_shortcut(&mut self) -> &mut Self {
         match self.current_shortcut {
-            CurrentShortcut::MyTasks => self.current_shortcut = CurrentShortcut::RecentlyCompleted,
-            CurrentShortcut::RecentlyCompleted => {
-                self.current_shortcut = CurrentShortcut::RecentlyEdited
-            }
-            CurrentShortcut::RecentlyEdited => {
-                self.current_shortcut = CurrentShortcut::RecentlyCreated
-            }
-            CurrentShortcut::RecentlyCreated => self.current_shortcut = CurrentShortcut::PastDue,
-            CurrentShortcut::PastDue => self.current_shortcut = CurrentShortcut::DueSoon,
-            CurrentShortcut::DueSoon => self.current_shortcut = CurrentShortcut::MyTasks,
+            Shortcut::MyTasks => self.current_shortcut = Shortcut::RecentlyCompleted,
+            Shortcut::RecentlyCompleted => self.current_shortcut = Shortcut::RecentlyEdited,
+            Shortcut::RecentlyEdited => self.current_shortcut = Shortcut::RecentlyCreated,
+            Shortcut::RecentlyCreated => self.current_shortcut = Shortcut::PastDue,
+            Shortcut::PastDue => self.current_shortcut = Shortcut::DueSoon,
+            Shortcut::DueSoon => self.current_shortcut = Shortcut::MyTasks,
         }
         self
     }
@@ -281,86 +273,86 @@ mod tests {
     #[test]
     fn current_menu() {
         let state = State {
-            current_menu: CurrentMenu::Status,
+            current_menu: Menu::Status,
             ..State::default()
         };
-        assert_eq!(*state.current_menu(), CurrentMenu::Status);
+        assert_eq!(*state.current_menu(), Menu::Status);
     }
 
     #[test]
     fn next_menu() {
         let mut state = State {
-            current_menu: CurrentMenu::Status,
+            current_menu: Menu::Status,
             ..State::default()
         };
         state.next_menu();
-        assert_eq!(state.current_menu, CurrentMenu::Shortcuts);
+        assert_eq!(state.current_menu, Menu::Shortcuts);
         state.next_menu();
-        assert_eq!(state.current_menu, CurrentMenu::TopList);
+        assert_eq!(state.current_menu, Menu::TopList);
         state.next_menu();
-        assert_eq!(state.current_menu, CurrentMenu::Status);
+        assert_eq!(state.current_menu, Menu::Status);
     }
 
     #[test]
     fn previous_menu() {
         let mut state = State {
-            current_menu: CurrentMenu::Status,
+            current_menu: Menu::Status,
             ..State::default()
         };
         state.previous_menu();
-        assert_eq!(state.current_menu, CurrentMenu::TopList);
+        assert_eq!(state.current_menu, Menu::TopList);
         state.previous_menu();
-        assert_eq!(state.current_menu, CurrentMenu::Shortcuts);
+        assert_eq!(state.current_menu, Menu::Shortcuts);
         state.previous_menu();
-        assert_eq!(state.current_menu, CurrentMenu::Status);
+        assert_eq!(state.current_menu, Menu::Status);
     }
 
     #[test]
     fn current_shortcut() {
         let state = State {
-            current_shortcut: CurrentShortcut::MyTasks,
+            current_shortcut: Shortcut::MyTasks,
             ..State::default()
         };
-        assert_eq!(*state.current_shortcut(), CurrentShortcut::MyTasks);
+        assert_eq!(*state.current_shortcut(), Shortcut::MyTasks);
     }
 
     #[test]
     fn next_shortcut() {
         let mut state = State {
-            current_shortcut: CurrentShortcut::MyTasks,
+            current_shortcut: Shortcut::MyTasks,
             ..State::default()
         };
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::DueSoon);
+        assert_eq!(state.current_shortcut, Shortcut::DueSoon);
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::PastDue);
+        assert_eq!(state.current_shortcut, Shortcut::PastDue);
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::RecentlyCreated);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyCreated);
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::RecentlyEdited);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyEdited);
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::RecentlyCompleted);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyCompleted);
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::MyTasks);
+        assert_eq!(state.current_shortcut, Shortcut::MyTasks);
     }
 
     #[test]
     fn previous_shortcut() {
         let mut state = State {
-            current_shortcut: CurrentShortcut::MyTasks,
+            current_shortcut: Shortcut::MyTasks,
             ..State::default()
         };
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::RecentlyCompleted);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyCompleted);
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::RecentlyEdited);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyEdited);
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::RecentlyCreated);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyCreated);
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::PastDue);
+        assert_eq!(state.current_shortcut, Shortcut::PastDue);
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::DueSoon);
+        assert_eq!(state.current_shortcut, Shortcut::DueSoon);
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, CurrentShortcut::MyTasks);
+        assert_eq!(state.current_shortcut, Shortcut::MyTasks);
     }
 }

--- a/src/ui/render/shortcuts.rs
+++ b/src/ui/render/shortcuts.rs
@@ -1,5 +1,5 @@
 use super::Frame;
-use crate::state::{CurrentMenu, CurrentShortcut, State};
+use crate::state::{Menu, Shortcut, State};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
@@ -23,7 +23,7 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
     let mut recently_completed_style = Style::default();
 
     let mut list_item_style = styling::current_list_item_style();
-    if *state.current_menu() == CurrentMenu::Shortcuts {
+    if *state.current_menu() == Menu::Shortcuts {
         block = block
             .border_style(styling::active_block_border_style())
             .title(Span::styled(
@@ -34,22 +34,22 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
     }
 
     match state.current_shortcut() {
-        CurrentShortcut::MyTasks => {
+        Shortcut::MyTasks => {
             my_tasks_style = list_item_style;
         }
-        CurrentShortcut::DueSoon => {
+        Shortcut::DueSoon => {
             due_soon_style = list_item_style;
         }
-        CurrentShortcut::PastDue => {
+        Shortcut::PastDue => {
             past_due_style = list_item_style;
         }
-        CurrentShortcut::RecentlyCreated => {
+        Shortcut::RecentlyCreated => {
             recently_created_style = list_item_style;
         }
-        CurrentShortcut::RecentlyEdited => {
+        Shortcut::RecentlyEdited => {
             recently_edited_style = list_item_style;
         }
-        CurrentShortcut::RecentlyCompleted => {
+        Shortcut::RecentlyCompleted => {
             recently_completed_style = list_item_style;
         }
     };

--- a/src/ui/render/status.rs
+++ b/src/ui/render/status.rs
@@ -1,6 +1,6 @@
 use super::widgets::spinner;
 use super::Frame;
-use crate::state::{CurrentMenu, State};
+use crate::state::{Menu, State};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
@@ -14,7 +14,7 @@ const BLOCK_TITLE: &str = "Status";
 ///
 pub fn status(frame: &mut Frame, size: Rect, state: &State) {
     let mut block = Block::default().title(BLOCK_TITLE).borders(Borders::ALL);
-    if *state.current_menu() == CurrentMenu::Status {
+    if *state.current_menu() == Menu::Status {
         block = block
             .border_style(styling::active_block_border_style())
             .title(Span::styled(

--- a/src/ui/render/top_list.rs
+++ b/src/ui/render/top_list.rs
@@ -1,5 +1,5 @@
 use super::Frame;
-use crate::state::{CurrentMenu, State};
+use crate::state::{Menu, State};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
@@ -13,7 +13,7 @@ const BLOCK_TITLE: &str = "Projects";
 ///
 pub fn top_list(frame: &mut Frame, size: Rect, state: &State) {
     let mut block = Block::default().title(BLOCK_TITLE).borders(Borders::ALL);
-    if *state.current_menu() == CurrentMenu::TopList {
+    if *state.current_menu() == Menu::TopList {
         block = block
             .border_style(styling::active_block_border_style())
             .title(Span::styled(


### PR DESCRIPTION
Removing the unnecessary prefix "current" from the enums declared in the state module and updating usages throughout the project.