### PR TITLE
Allowing shortcut selection to change view and focus

### DIFF
--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -1,0 +1,70 @@
+/// Oversees management of view data.
+///
+#[derive(Debug, PartialEq, Eq)]
+pub struct View {
+    title: String,
+}
+
+impl View {
+    /// Returns the view title.
+    ///
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+}
+
+/// Returns the default welcome view.
+///
+pub fn welcome() -> View {
+    View {
+        title: String::from("Welcome"),
+    }
+}
+
+/// Returns the default my-tasks view.
+///
+pub fn my_tasks() -> View {
+    View {
+        title: String::from("My Tasks"),
+    }
+}
+
+/// Returns the default due-soon view.
+///
+pub fn due_soon() -> View {
+    View {
+        title: String::from("Due Soon"),
+    }
+}
+
+/// Returns the default past-due view.
+///
+pub fn past_due() -> View {
+    View {
+        title: String::from("Past Due"),
+    }
+}
+
+/// Returns the default recently-created view.
+///
+pub fn recently_created() -> View {
+    View {
+        title: String::from("Recently Created"),
+    }
+}
+
+/// Returns the default recently-edited view.
+///
+pub fn recently_edited() -> View {
+    View {
+        title: String::from("Recently Edited"),
+    }
+}
+
+/// Returns the default recently-completed view.
+///
+pub fn recently_completed() -> View {
+    View {
+        title: String::from("Recently Completed"),
+    }
+}

--- a/src/ui/render/main.rs
+++ b/src/ui/render/main.rs
@@ -1,13 +1,25 @@
 use super::Frame;
-use crate::state::State;
+use crate::state::{Focus, State};
+use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
+    text::Span,
     widgets::{Block, Borders},
 };
 
 /// Render main widget according to state.
 ///
-pub fn main(frame: &mut Frame, size: Rect, _state: &State) {
-    let block = Block::default().borders(Borders::ALL);
+pub fn main(frame: &mut Frame, size: Rect, state: &State) {
+    let mut block = Block::default().borders(Borders::ALL);
+    let block_title = state.current_view().title();
+
+    if *state.current_focus() == Focus::View {
+        block = block.border_style(styling::active_block_border_style());
+    }
+    block = block.title(Span::styled(
+        block_title,
+        styling::active_block_title_style(),
+    ));
+
     frame.render_widget(block, size);
 }

--- a/src/ui/render/shortcuts.rs
+++ b/src/ui/render/shortcuts.rs
@@ -1,5 +1,5 @@
 use super::Frame;
-use crate::state::{Menu, Shortcut, State};
+use crate::state::{Focus, Menu, Shortcut, State};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
@@ -23,7 +23,7 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
     let mut recently_completed_style = Style::default();
 
     let mut list_item_style = styling::current_list_item_style();
-    if *state.current_menu() == Menu::Shortcuts {
+    if *state.current_focus() == Focus::Menu && *state.current_menu() == Menu::Shortcuts {
         block = block
             .border_style(styling::active_block_border_style())
             .title(Span::styled(


### PR DESCRIPTION
When the user selects a shortcut with the enter key, the view stack is cleared and the view corresponding to the shortcut is rendered in the main widget which is then given focus. The user can return focus to the current menu on the left with the escape key.