### PR TITLE
Restructuring left menus

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -34,7 +34,7 @@ impl App {
     /// the result of the application execution.
     ///
     pub async fn start(config: Config) -> Result<()> {
-        init_logger(LevelFilter::Debug).unwrap();
+        init_logger(LevelFilter::Info).unwrap();
         set_default_level(LevelFilter::Trace);
 
         info!("Starting application...");

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,10 +28,7 @@ pub enum Menu {
 pub enum View {
     Welcome,
     MyTasks,
-    DueSoon,
-    PastDue,
-    RecentlyCreated,
-    RecentlyEdited,
+    RecentlyModified,
     RecentlyCompleted,
 }
 
@@ -40,10 +37,7 @@ pub enum View {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Shortcut {
     MyTasks,
-    DueSoon,
-    PastDue,
-    RecentlyCreated,
-    RecentlyEdited,
+    RecentlyModified,
     RecentlyCompleted,
 }
 
@@ -212,11 +206,8 @@ impl State {
     ///
     pub fn next_shortcut(&mut self) -> &mut Self {
         match self.current_shortcut {
-            Shortcut::MyTasks => self.current_shortcut = Shortcut::DueSoon,
-            Shortcut::DueSoon => self.current_shortcut = Shortcut::PastDue,
-            Shortcut::PastDue => self.current_shortcut = Shortcut::RecentlyCreated,
-            Shortcut::RecentlyCreated => self.current_shortcut = Shortcut::RecentlyEdited,
-            Shortcut::RecentlyEdited => self.current_shortcut = Shortcut::RecentlyCompleted,
+            Shortcut::MyTasks => self.current_shortcut = Shortcut::RecentlyModified,
+            Shortcut::RecentlyModified => self.current_shortcut = Shortcut::RecentlyCompleted,
             Shortcut::RecentlyCompleted => self.current_shortcut = Shortcut::MyTasks,
         }
         self
@@ -227,11 +218,8 @@ impl State {
     pub fn previous_shortcut(&mut self) -> &mut Self {
         match self.current_shortcut {
             Shortcut::MyTasks => self.current_shortcut = Shortcut::RecentlyCompleted,
-            Shortcut::RecentlyCompleted => self.current_shortcut = Shortcut::RecentlyEdited,
-            Shortcut::RecentlyEdited => self.current_shortcut = Shortcut::RecentlyCreated,
-            Shortcut::RecentlyCreated => self.current_shortcut = Shortcut::PastDue,
-            Shortcut::PastDue => self.current_shortcut = Shortcut::DueSoon,
-            Shortcut::DueSoon => self.current_shortcut = Shortcut::MyTasks,
+            Shortcut::RecentlyCompleted => self.current_shortcut = Shortcut::RecentlyModified,
+            Shortcut::RecentlyModified => self.current_shortcut = Shortcut::MyTasks,
         }
         self
     }
@@ -246,17 +234,8 @@ impl State {
                 self.dispatch(NetworkEvent::MyTasks);
                 self.view_stack.push(View::MyTasks);
             }
-            Shortcut::DueSoon => {
-                self.view_stack.push(View::DueSoon);
-            }
-            Shortcut::PastDue => {
-                self.view_stack.push(View::PastDue);
-            }
-            Shortcut::RecentlyCreated => {
-                self.view_stack.push(View::RecentlyCreated);
-            }
-            Shortcut::RecentlyEdited => {
-                self.view_stack.push(View::RecentlyEdited);
+            Shortcut::RecentlyModified => {
+                self.view_stack.push(View::RecentlyModified);
             }
             Shortcut::RecentlyCompleted => {
                 self.view_stack.push(View::RecentlyCompleted);
@@ -472,13 +451,7 @@ mod tests {
             ..State::default()
         };
         state.next_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::DueSoon);
-        state.next_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::PastDue);
-        state.next_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::RecentlyCreated);
-        state.next_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::RecentlyEdited);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyModified);
         state.next_shortcut();
         assert_eq!(state.current_shortcut, Shortcut::RecentlyCompleted);
         state.next_shortcut();
@@ -494,13 +467,7 @@ mod tests {
         state.previous_shortcut();
         assert_eq!(state.current_shortcut, Shortcut::RecentlyCompleted);
         state.previous_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::RecentlyEdited);
-        state.previous_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::RecentlyCreated);
-        state.previous_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::PastDue);
-        state.previous_shortcut();
-        assert_eq!(state.current_shortcut, Shortcut::DueSoon);
+        assert_eq!(state.current_shortcut, Shortcut::RecentlyModified);
         state.previous_shortcut();
         assert_eq!(state.current_shortcut, Shortcut::MyTasks);
     }
@@ -515,19 +482,19 @@ mod tests {
         state.select_current_shortcut();
         assert_eq!(*state.view_stack.last().unwrap(), View::MyTasks);
         assert_eq!(state.current_focus, Focus::View);
-        state.current_shortcut = Shortcut::PastDue;
+        state.current_shortcut = Shortcut::RecentlyModified;
         state.select_current_shortcut();
-        assert_eq!(*state.view_stack.last().unwrap(), View::PastDue);
+        assert_eq!(*state.view_stack.last().unwrap(), View::RecentlyModified);
         assert_eq!(state.current_focus, Focus::View);
     }
 
     #[test]
     fn current_view() {
         let mut state = State {
-            view_stack: vec![View::DueSoon],
+            view_stack: vec![View::MyTasks],
             ..State::default()
         };
-        assert_eq!(*state.current_view(), View::DueSoon);
+        assert_eq!(*state.current_view(), View::MyTasks);
         state.view_stack = vec![View::RecentlyCompleted];
         assert_eq!(*state.current_view(), View::RecentlyCompleted);
     }

--- a/src/ui/render/all.rs
+++ b/src/ui/render/all.rs
@@ -26,8 +26,8 @@ fn left(frame: &mut Frame, size: Rect, state: &State) {
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(4),
-            Constraint::Length(8),
+            Constraint::Length(5),
+            Constraint::Length(5),
             Constraint::Min(1),
         ])
         .split(size);

--- a/src/ui/render/main.rs
+++ b/src/ui/render/main.rs
@@ -17,17 +17,8 @@ pub fn main(frame: &mut Frame, size: Rect, state: &State) {
         View::MyTasks => {
             my_tasks(frame, size, state);
         }
-        View::DueSoon => {
-            due_soon(frame, size, state);
-        }
-        View::PastDue => {
-            past_due(frame, size, state);
-        }
-        View::RecentlyCreated => {
-            recently_created(frame, size, state);
-        }
-        View::RecentlyEdited => {
-            recently_edited(frame, size, state);
+        View::RecentlyModified => {
+            recently_modified(frame, size, state);
         }
         View::RecentlyCompleted => {
             recently_completed(frame, size, state);
@@ -46,26 +37,8 @@ fn my_tasks(frame: &mut Frame, size: Rect, state: &State) {
     frame.render_widget(list, size);
 }
 
-fn due_soon(frame: &mut Frame, size: Rect, state: &State) {
-    let block = view_block("Due Soon", state);
-    let list = task_list(state).block(block);
-    frame.render_widget(list, size);
-}
-
-fn past_due(frame: &mut Frame, size: Rect, state: &State) {
-    let block = view_block("Past Due", state);
-    let list = task_list(state).block(block);
-    frame.render_widget(list, size);
-}
-
-fn recently_created(frame: &mut Frame, size: Rect, state: &State) {
-    let block = view_block("Recently Created", state);
-    let list = task_list(state).block(block);
-    frame.render_widget(list, size);
-}
-
-fn recently_edited(frame: &mut Frame, size: Rect, state: &State) {
-    let block = view_block("Recently Edited", state);
+fn recently_modified(frame: &mut Frame, size: Rect, state: &State) {
+    let block = view_block("Recently Modified", state);
     let list = task_list(state).block(block);
     frame.render_widget(list, size);
 }

--- a/src/ui/render/shortcuts.rs
+++ b/src/ui/render/shortcuts.rs
@@ -16,10 +16,7 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
     let mut block = Block::default().title(BLOCK_TITLE).borders(Borders::ALL);
 
     let mut my_tasks_style = Style::default();
-    let mut due_soon_style = Style::default();
-    let mut past_due_style = Style::default();
-    let mut recently_created_style = Style::default();
-    let mut recently_edited_style = Style::default();
+    let mut recently_modified_style = Style::default();
     let mut recently_completed_style = Style::default();
 
     let mut list_item_style = styling::current_list_item_style();
@@ -37,17 +34,8 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
         Shortcut::MyTasks => {
             my_tasks_style = list_item_style;
         }
-        Shortcut::DueSoon => {
-            due_soon_style = list_item_style;
-        }
-        Shortcut::PastDue => {
-            past_due_style = list_item_style;
-        }
-        Shortcut::RecentlyCreated => {
-            recently_created_style = list_item_style;
-        }
-        Shortcut::RecentlyEdited => {
-            recently_edited_style = list_item_style;
+        Shortcut::RecentlyModified => {
+            recently_modified_style = list_item_style;
         }
         Shortcut::RecentlyCompleted => {
             recently_completed_style = list_item_style;
@@ -56,13 +44,10 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
 
     let text = vec![
         Spans::from(vec![Span::styled("My Tasks", my_tasks_style)]),
-        Spans::from(vec![Span::styled("Due Soon", due_soon_style)]),
-        Spans::from(vec![Span::styled("Past Due", past_due_style)]),
         Spans::from(vec![Span::styled(
-            "Recently Created",
-            recently_created_style,
+            "Recently Modified",
+            recently_modified_style,
         )]),
-        Spans::from(vec![Span::styled("Recently Edited", recently_edited_style)]),
         Spans::from(vec![Span::styled(
             "Recently Completed",
             recently_completed_style,

--- a/src/ui/render/status.rs
+++ b/src/ui/render/status.rs
@@ -31,10 +31,8 @@ pub fn status(frame: &mut Frame, size: Rect, state: &State) {
     let user = state.get_user().unwrap();
     let workspace = state.get_active_workspace().unwrap();
     let text = vec![
-        Spans::from(vec![Span::raw(format!(
-            "User: {} <{}>",
-            &user.name, &user.email
-        ))]),
+        Spans::from(vec![Span::raw(format!("User: {}", &user.name))]),
+        Spans::from(vec![Span::raw(format!("Email: {}", &user.email))]),
         Spans::from(vec![Span::raw("Workspace: "), Span::raw(&workspace.name)]),
     ];
     let paragraph = Paragraph::new(text).block(block);

--- a/src/ui/render/status.rs
+++ b/src/ui/render/status.rs
@@ -24,7 +24,7 @@ pub fn status(frame: &mut Frame, size: Rect, state: &State) {
     }
 
     if state.get_user().is_none() || state.get_active_workspace().is_none() {
-        frame.render_widget(spinner::widget(state).block(block), size);
+        frame.render_widget(spinner::widget(state, size.height).block(block), size);
         return;
     }
 

--- a/src/ui/widgets/spinner.rs
+++ b/src/ui/widgets/spinner.rs
@@ -7,13 +7,20 @@ use tui::{
 
 /// Define frames for loading indicator.
 ///
-pub const FRAMES: &[&str] = &["▁ ▂ ▃", "▁ ▂ ▃", "▂ ▃ ▁", "▂ ▃ ▁", "▃ ▁ ▂", "▃ ▁ ▂"];
+pub const FRAMES: &[&str] = &["▄ ▆ ▇", "▄ ▆ ▇", "▆ ▇ ▄", "▆ ▇ ▄", "▇ ▄ ▆", "▇ ▄ ▆"];
 
 /// Build the spinner widget according to state.
 ///
-pub fn widget(state: &State) -> Paragraph {
-    let text = vec![Spans::from(vec![Span::raw(
+pub fn widget(state: &State, container_height: u16) -> Paragraph {
+    // Remove a line for each border (top and bottom) as well as the line the
+    // widget will be drawn on. Finally divide in half.
+    let vertical_line_offset = (container_height - 3) / 2;
+
+    let mut text = vec![Spans::from(vec![Span::raw(
         FRAMES[*state.get_spinner_index()],
     )])];
+    for _ in 0..vertical_line_offset {
+        text.insert(0, Spans::from(vec![Span::raw("")]));
+    }
     Paragraph::new(text).alignment(Alignment::Center)
 }


### PR DESCRIPTION
The previously-listed shortcut menu items would not all be possible without a premium user account. After removing those shortcut menu items, the left menus have been restructured to better take advantage of the available vertical space. Specifically, the shortcuts menu height has been reduced to fit the available items exactly and the status menu now includes the user email on a separate line. 