### PR TITLE
Rendering relevant tasks in list view following project selection

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,7 +92,6 @@ impl App {
         terminal.hide_cursor()?;
 
         net_sender.send(NetworkEvent::Me)?;
-        net_sender.send(NetworkEvent::Projects)?;
 
         let terminal_event_handler = TerminalEventHandler::new();
         loop {

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,6 +92,7 @@ impl App {
         terminal.hide_cursor()?;
 
         net_sender.send(NetworkEvent::Me)?;
+        net_sender.send(NetworkEvent::Projects)?;
 
         let terminal_event_handler = TerminalEventHandler::new();
         loop {

--- a/src/asana/mod.rs
+++ b/src/asana/mod.rs
@@ -21,7 +21,10 @@ impl Asana {
     /// Returns a new instance for the given access token.
     ///
     pub fn new(access_token: &str) -> Asana {
-        info!("Initializing Asana client with personal access token...");
+        debug!(
+            "Initializing Asana client with personal access token {}...",
+            access_token
+        );
         Asana {
             client: Client::new(access_token, "https://app.asana.com/api/1.0"),
         }
@@ -31,7 +34,7 @@ impl Asana {
     /// they have access.
     ///
     pub async fn me(&mut self) -> Result<(User, Vec<Workspace>)> {
-        info!("Fetching authenticated user details...");
+        debug!("Requesting authenticated user details...");
 
         model!(WorkspaceModel "workspaces" { name: String });
         model!(UserModel "users" {
@@ -41,7 +44,6 @@ impl Asana {
         } WorkspaceModel);
 
         let data = self.client.get::<UserModel>("me").await?;
-        info!("Received authenticated user details.");
 
         Ok((
             User {
@@ -62,7 +64,7 @@ impl Asana {
     /// Returns a vector of projects for the workspace.
     ///
     pub async fn projects(&mut self, workspace_gid: &str) -> Result<Vec<Project>> {
-        info!("Fetching projects for the workspace...");
+        debug!("Requesting projects for workspace GID {}...", workspace_gid);
 
         model!(ProjectModel "projects" { name: String });
 
@@ -70,7 +72,6 @@ impl Asana {
             .client
             .list::<ProjectModel>(Some(vec![("workspace", workspace_gid)]))
             .await?;
-        info!("Received projects for the workspace.");
 
         Ok(data
             .into_iter()
@@ -105,7 +106,10 @@ impl Asana {
     /// Returns a vector of incomplete tasks assigned to the user.
     ///
     pub async fn my_tasks(&mut self, user_gid: &str, workspace_gid: &str) -> Result<Vec<Task>> {
-        info!("Fetching tasks assigned to user...");
+        debug!(
+            "Requesting tasks for user GID {} and workspace GID {}...",
+            user_gid, workspace_gid
+        );
 
         model!(TaskModel "tasks" { name: String });
 
@@ -120,7 +124,6 @@ impl Asana {
                 ),
             ]))
             .await?;
-        info!("Received incomplete tasks assigned to user.");
 
         Ok(data
             .into_iter()

--- a/src/asana/mod.rs
+++ b/src/asana/mod.rs
@@ -213,7 +213,7 @@ mod tests {
         let token: Uuid = UUIDv4.fake();
         let user: User = Faker.fake();
         let workspace: Workspace = Faker.fake();
-        let task: [Task; 2] = Faker.fake();
+        let tasks: [Task; 2] = Faker.fake();
 
         let server = MockServer::start();
         let mock = server
@@ -227,14 +227,14 @@ mod tests {
                 then.status(200).json_body(json!({
                     "data": [
                         {
-                            "gid": task[0].gid,
+                            "gid": tasks[0].gid,
                             "resource_type": "task",
-                            "name": task[0].name,
+                            "name": tasks[0].name,
                         },
                         {
-                            "gid": task[1].gid,
+                            "gid": tasks[1].gid,
                             "resource_type": "task",
-                            "name": task[1].name,
+                            "name": tasks[1].name,
                         }
                     ]
                 }));

--- a/src/asana/resource.rs
+++ b/src/asana/resource.rs
@@ -24,3 +24,11 @@ pub struct Task {
     pub gid: String,
     pub name: String,
 }
+
+/// Defines project data structure.
+///
+#[derive(Clone, Debug, Dummy, PartialEq)]
+pub struct Project {
+    pub gid: String,
+    pub name: String,
+}

--- a/src/events/network.rs
+++ b/src/events/network.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 #[derive(Debug)]
 pub enum Event {
     Me,
+    Projects,
     MyTasks,
 }
 
@@ -33,6 +34,7 @@ impl<'a> Handler<'a> {
         debug!("Processing network event '{:?}'...", event);
         match event {
             Event::Me => self.me().await?,
+            Event::Projects => self.projects().await?,
             Event::MyTasks => self.my_tasks().await?,
         }
         Ok(())
@@ -48,6 +50,18 @@ impl<'a> Handler<'a> {
             state.set_active_workspace(workspaces[0].gid.to_owned());
         }
         state.set_workspaces(workspaces);
+        Ok(())
+    }
+
+    /// Update state with projects.
+    ///
+    async fn projects(&mut self) -> Result<()> {
+        let mut state = self.state.lock().await;
+        let projects = self
+            .asana
+            .projects(&state.get_active_workspace().unwrap().gid)
+            .await?;
+        state.set_projects(projects);
         Ok(())
     }
 

--- a/src/events/network.rs
+++ b/src/events/network.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 #[derive(Debug)]
 pub enum Event {
     Me,
-    Projects,
+    ProjectTasks,
     MyTasks,
 }
 
@@ -34,40 +34,52 @@ impl<'a> Handler<'a> {
         debug!("Processing network event '{:?}'...", event);
         match event {
             Event::Me => self.me().await?,
-            Event::Projects => self.projects().await?,
+            Event::ProjectTasks => self.project_tasks().await?,
             Event::MyTasks => self.my_tasks().await?,
         }
         Ok(())
     }
 
-    /// Update state with user details.
+    /// Update state with user details and projects for active workspace.
     ///
     async fn me(&mut self) -> Result<()> {
+        info!("Preparing initial application data...");
+        info!("Fetching user details and available workspaces...");
         let (user, workspaces) = self.asana.me().await?;
+        let mut projects = vec![];
+        if !workspaces.is_empty() {
+            info!("Fetching projects for active workspace...");
+            projects = self.asana.projects(&workspaces[0].gid).await?;
+        }
         let mut state = self.state.lock().await;
         state.set_user(user);
-        if !workspaces.is_empty() && state.get_active_workspace().is_none() {
-            state.set_active_workspace(workspaces[0].gid.to_owned());
-        }
+        state.set_active_workspace(workspaces[0].gid.to_owned());
         state.set_workspaces(workspaces);
+        state.set_projects(projects);
+        info!("Loaded initial application data.");
         Ok(())
     }
 
-    /// Update state with projects.
+    /// Update state with tasks for project.
     ///
-    async fn projects(&mut self) -> Result<()> {
+    async fn project_tasks(&mut self) -> Result<()> {
         let mut state = self.state.lock().await;
-        let projects = self
-            .asana
-            .projects(&state.get_active_workspace().unwrap().gid)
-            .await?;
-        state.set_projects(projects);
+        let project = state.get_project();
+        if project.is_none() {
+            warn!("Skipping tasks request for unset project.");
+            return Ok(());
+        }
+        info!("Fetching tasks for project '{}'...", &project.unwrap().name);
+        let tasks = self.asana.tasks(&project.unwrap().gid).await?;
+        info!("Received tasks for project '{}'.", &project.unwrap().name);
+        state.set_tasks(tasks);
         Ok(())
     }
 
     /// Update state with tasks assigned to the user.
     ///
     async fn my_tasks(&mut self) -> Result<()> {
+        info!("Fetching incomplete tasks assigned to user...");
         let mut state = self.state.lock().await;
         let my_tasks = self
             .asana
@@ -77,6 +89,7 @@ impl<'a> Handler<'a> {
             )
             .await?;
         state.set_tasks(my_tasks);
+        info!("Received incomplete tasks assigned to user.");
         Ok(())
     }
 }

--- a/src/events/terminal.rs
+++ b/src/events/terminal.rs
@@ -137,7 +137,9 @@ impl Handler {
                             Menu::Shortcuts => {
                                 state.select_current_shortcut();
                             }
-                            Menu::TopList => (),
+                            Menu::TopList => {
+                                state.select_current_top_list_item();
+                            }
                         }
                     }
                     Focus::View => {}

--- a/src/events/terminal.rs
+++ b/src/events/terminal.rs
@@ -101,7 +101,9 @@ impl Handler {
                             Menu::Shortcuts => {
                                 state.previous_shortcut();
                             }
-                            Menu::TopList => (),
+                            Menu::TopList => {
+                                state.previous_top_list_item();
+                            }
                         }
                     }
                     Focus::View => {}
@@ -117,7 +119,9 @@ impl Handler {
                             Menu::Shortcuts => {
                                 state.next_shortcut();
                             }
-                            Menu::TopList => (),
+                            Menu::TopList => {
+                                state.next_top_list_item();
+                            }
                         }
                     }
                     Focus::View => {}

--- a/src/state.rs
+++ b/src/state.rs
@@ -284,7 +284,7 @@ impl State {
     /// Select the current top list item.
     ///
     pub fn select_current_top_list_item(&mut self) -> &mut Self {
-        if self.projects.len() == 0 {
+        if self.projects.is_empty() {
             return self;
         }
         self.project = Some(self.projects[self.current_top_list_item].to_owned());

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,6 +30,7 @@ pub enum View {
     MyTasks,
     RecentlyModified,
     RecentlyCompleted,
+    ProjectTasks,
 }
 
 /// Specifying the different shortcuts.
@@ -57,6 +58,7 @@ pub struct State {
     view_stack: Vec<View>,
     tasks: Vec<Task>,
     projects: Vec<Project>,
+    project: Option<Project>,
 }
 
 /// Defines default application state.
@@ -77,6 +79,7 @@ impl Default for State {
             view_stack: vec![View::Welcome],
             tasks: vec![],
             projects: vec![],
+            project: None,
         }
     }
 }
@@ -239,9 +242,11 @@ impl State {
                 self.view_stack.push(View::MyTasks);
             }
             Shortcut::RecentlyModified => {
+                self.tasks.clear();
                 self.view_stack.push(View::RecentlyModified);
             }
             Shortcut::RecentlyCompleted => {
+                self.tasks.clear();
                 self.view_stack.push(View::RecentlyCompleted);
             }
         }
@@ -276,6 +281,21 @@ impl State {
         &self.current_top_list_item
     }
 
+    /// Select the current top list item.
+    ///
+    pub fn select_current_top_list_item(&mut self) -> &mut Self {
+        if self.projects.len() == 0 {
+            return self;
+        }
+        self.project = Some(self.projects[self.current_top_list_item].to_owned());
+        self.view_stack.clear();
+        self.tasks.clear();
+        self.dispatch(NetworkEvent::ProjectTasks);
+        self.view_stack.push(View::ProjectTasks);
+        self.focus_view();
+        self
+    }
+
     /// Return the current view.
     ///
     pub fn current_view(&self) -> &View {
@@ -306,6 +326,12 @@ impl State {
     pub fn set_projects(&mut self, projects: Vec<Project>) -> &mut Self {
         self.projects = projects;
         self
+    }
+
+    /// Return the current project.
+    ///
+    pub fn get_project(&self) -> Option<&Project> {
+        self.project.as_ref()
     }
 
     /// Dispatches an asynchronous network event.

--- a/src/state.rs
+++ b/src/state.rs
@@ -53,6 +53,7 @@ pub struct State {
     current_focus: Focus,
     current_menu: Menu,
     current_shortcut: Shortcut,
+    current_top_list_item: usize,
     view_stack: Vec<View>,
     tasks: Vec<Task>,
     projects: Vec<Project>,
@@ -72,6 +73,7 @@ impl Default for State {
             current_focus: Focus::Menu,
             current_menu: Menu::Shortcuts,
             current_shortcut: Shortcut::MyTasks,
+            current_top_list_item: 0,
             view_stack: vec![View::Welcome],
             tasks: vec![],
             projects: vec![],
@@ -245,6 +247,33 @@ impl State {
         }
         self.focus_view();
         self
+    }
+
+    /// Activate the next top list item.
+    ///
+    pub fn next_top_list_item(&mut self) -> &mut Self {
+        self.current_top_list_item += 1;
+        if self.current_top_list_item >= self.projects.len() {
+            self.current_top_list_item = 0;
+        }
+        self
+    }
+
+    /// Activate the previous top list item.
+    ///
+    pub fn previous_top_list_item(&mut self) -> &mut Self {
+        if self.current_top_list_item > 0 {
+            self.current_top_list_item -= 1;
+        } else {
+            self.current_top_list_item = self.projects.len() - 1;
+        }
+        self
+    }
+
+    /// Return the current top list item.
+    ///
+    pub fn current_top_list_item(&self) -> &usize {
+        &self.current_top_list_item
     }
 
     /// Return the current view.
@@ -501,6 +530,43 @@ mod tests {
         state.select_current_shortcut();
         assert_eq!(*state.view_stack.last().unwrap(), View::RecentlyModified);
         assert_eq!(state.current_focus, Focus::View);
+    }
+
+    #[test]
+    fn current_top_list_item() {
+        let state = State {
+            current_top_list_item: 2,
+            ..State::default()
+        };
+        assert_eq!(*state.current_top_list_item(), 2);
+    }
+
+    #[test]
+    fn next_top_list_item() {
+        let projects = vec![Faker.fake::<Project>(), Faker.fake::<Project>()];
+        let mut state = State {
+            current_top_list_item: 0,
+            projects,
+            ..State::default()
+        };
+        state.next_top_list_item();
+        assert_eq!(state.current_top_list_item, 1);
+        state.next_top_list_item();
+        assert_eq!(state.current_top_list_item, 0);
+    }
+
+    #[test]
+    fn previous_top_list_item() {
+        let projects = vec![Faker.fake::<Project>(), Faker.fake::<Project>()];
+        let mut state = State {
+            current_top_list_item: 0,
+            projects,
+            ..State::default()
+        };
+        state.previous_top_list_item();
+        assert_eq!(state.current_top_list_item, 1);
+        state.previous_top_list_item();
+        assert_eq!(state.current_top_list_item, 0);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use crate::app::NetworkEventSender;
-use crate::asana::{Task, User, Workspace};
+use crate::asana::{Project, Task, User, Workspace};
 use crate::events::network::Event as NetworkEvent;
 use crate::ui::SPINNER_FRAME_COUNT;
 use log::*;
@@ -55,6 +55,7 @@ pub struct State {
     current_shortcut: Shortcut,
     view_stack: Vec<View>,
     tasks: Vec<Task>,
+    projects: Vec<Project>,
 }
 
 /// Defines default application state.
@@ -73,6 +74,7 @@ impl Default for State {
             current_shortcut: Shortcut::MyTasks,
             view_stack: vec![View::Welcome],
             tasks: vec![],
+            projects: vec![],
         }
     }
 }
@@ -261,6 +263,19 @@ impl State {
     ///
     pub fn set_tasks(&mut self, tasks: Vec<Task>) -> &mut Self {
         self.tasks = tasks;
+        self
+    }
+
+    /// Return the list of projects.
+    ///
+    pub fn get_projects(&self) -> &Vec<Project> {
+        &self.projects
+    }
+
+    /// Set the list of projects.
+    ///
+    pub fn set_projects(&mut self, projects: Vec<Project>) -> &mut Self {
+        self.projects = projects;
         self
     }
 
@@ -523,5 +538,31 @@ mod tests {
         ];
         state.set_tasks(tasks.to_owned());
         assert_eq!(tasks, state.tasks);
+    }
+
+    #[test]
+    fn get_projects() {
+        let projects = vec![
+            Faker.fake::<Project>(),
+            Faker.fake::<Project>(),
+            Faker.fake::<Project>(),
+        ];
+        let state = State {
+            projects: projects.to_owned(),
+            ..State::default()
+        };
+        assert_eq!(projects, *state.get_projects());
+    }
+
+    #[test]
+    fn set_projects() {
+        let mut state = State::default();
+        let projects = vec![
+            Faker.fake::<Project>(),
+            Faker.fake::<Project>(),
+            Faker.fake::<Project>(),
+        ];
+        state.set_projects(projects.to_owned());
+        assert_eq!(projects, state.projects);
     }
 }

--- a/src/ui/render/main.rs
+++ b/src/ui/render/main.rs
@@ -1,3 +1,4 @@
+use super::widgets::spinner;
 use super::Frame;
 use crate::state::{Focus, State, View};
 use crate::ui::widgets::styling;
@@ -36,19 +37,19 @@ fn welcome(frame: &mut Frame, size: Rect, state: &State) {
 
 fn my_tasks(frame: &mut Frame, size: Rect, state: &State) {
     let block = view_block("My Tasks", state);
-    let list = task_list(state).block(block);
+    let list = task_list(state, size).block(block);
     frame.render_widget(list, size);
 }
 
 fn recently_modified(frame: &mut Frame, size: Rect, state: &State) {
     let block = view_block("Recently Modified", state);
-    let list = task_list(state).block(block);
+    let list = task_list(state, size).block(block);
     frame.render_widget(list, size);
 }
 
 fn recently_completed(frame: &mut Frame, size: Rect, state: &State) {
     let block = view_block("Recently Completed", state);
-    let list = task_list(state).block(block);
+    let list = task_list(state, size).block(block);
     frame.render_widget(list, size);
 }
 
@@ -58,11 +59,14 @@ fn project_tasks(frame: &mut Frame, size: Rect, state: &State) {
         None => "Project",
     };
     let block = view_block(title, state);
-    let list = task_list(state).block(block);
+    let list = task_list(state, size).block(block);
     frame.render_widget(list, size);
 }
 
-fn task_list(state: &State) -> Paragraph {
+fn task_list(state: &State, size: Rect) -> Paragraph {
+    if state.get_tasks().is_empty() {
+        return spinner::widget(state, size.height);
+    }
     let items: Vec<Spans> = state
         .get_tasks()
         .iter()

--- a/src/ui/render/main.rs
+++ b/src/ui/render/main.rs
@@ -23,6 +23,9 @@ pub fn main(frame: &mut Frame, size: Rect, state: &State) {
         View::RecentlyCompleted => {
             recently_completed(frame, size, state);
         }
+        View::ProjectTasks => {
+            project_tasks(frame, size, state);
+        }
     }
 }
 
@@ -45,6 +48,16 @@ fn recently_modified(frame: &mut Frame, size: Rect, state: &State) {
 
 fn recently_completed(frame: &mut Frame, size: Rect, state: &State) {
     let block = view_block("Recently Completed", state);
+    let list = task_list(state).block(block);
+    frame.render_widget(list, size);
+}
+
+fn project_tasks(frame: &mut Frame, size: Rect, state: &State) {
+    let title = match state.get_project() {
+        Some(project) => &project.name,
+        None => "Project",
+    };
+    let block = view_block(title, state);
     let list = task_list(state).block(block);
     frame.render_widget(list, size);
 }

--- a/src/ui/render/top_list.rs
+++ b/src/ui/render/top_list.rs
@@ -27,7 +27,7 @@ pub fn top_list(frame: &mut Frame, size: Rect, state: &State) {
         list_item_style = styling::current_list_item_style();
     }
 
-    if state.get_projects().len() == 0 {
+    if state.get_projects().is_empty() {
         frame.render_widget(spinner::widget(state, size.height).block(block), size);
         return;
     }

--- a/src/ui/render/top_list.rs
+++ b/src/ui/render/top_list.rs
@@ -1,6 +1,6 @@
 use super::widgets::spinner;
 use super::Frame;
-use crate::state::{Menu, State};
+use crate::state::{Focus, Menu, State};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
@@ -28,10 +28,26 @@ pub fn top_list(frame: &mut Frame, size: Rect, state: &State) {
         return;
     }
 
+    let list_item_style;
+    if *state.current_focus() == Focus::Menu && *state.current_menu() == Menu::TopList {
+        list_item_style = styling::active_list_item_style();
+    } else {
+        list_item_style = styling::current_list_item_style();
+    }
+
     let items: Vec<Spans> = state
         .get_projects()
         .iter()
-        .map(|p| Spans::from(vec![Span::raw(p.name.to_owned())]))
+        .enumerate()
+        .map(|(i, p)| {
+            let span;
+            if i == *state.current_top_list_item() {
+                span = Span::styled(p.name.to_owned(), list_item_style);
+            } else {
+                span = Span::raw(p.name.to_owned());
+            }
+            Spans::from(vec![span])
+        })
         .collect();
     let list = Paragraph::new(items)
         .style(styling::normal_list_item_style())

--- a/src/ui/render/top_list.rs
+++ b/src/ui/render/top_list.rs
@@ -14,25 +14,22 @@ const BLOCK_TITLE: &str = "Projects";
 ///
 pub fn top_list(frame: &mut Frame, size: Rect, state: &State) {
     let mut block = Block::default().title(BLOCK_TITLE).borders(Borders::ALL);
-    if *state.current_menu() == Menu::TopList {
+    let list_item_style;
+    if *state.current_focus() == Focus::Menu && *state.current_menu() == Menu::TopList {
+        list_item_style = styling::active_list_item_style();
         block = block
             .border_style(styling::active_block_border_style())
             .title(Span::styled(
                 BLOCK_TITLE,
                 styling::active_block_title_style(),
             ));
+    } else {
+        list_item_style = styling::current_list_item_style();
     }
 
     if state.get_projects().len() == 0 {
         frame.render_widget(spinner::widget(state, size.height).block(block), size);
         return;
-    }
-
-    let list_item_style;
-    if *state.current_focus() == Focus::Menu && *state.current_menu() == Menu::TopList {
-        list_item_style = styling::active_list_item_style();
-    } else {
-        list_item_style = styling::current_list_item_style();
     }
 
     let items: Vec<Spans> = state

--- a/src/ui/render/top_list.rs
+++ b/src/ui/render/top_list.rs
@@ -1,3 +1,4 @@
+use super::widgets::spinner;
 use super::Frame;
 use crate::state::{Menu, State};
 use crate::ui::widgets::styling;
@@ -21,6 +22,12 @@ pub fn top_list(frame: &mut Frame, size: Rect, state: &State) {
                 styling::active_block_title_style(),
             ));
     }
+
+    if state.get_projects().len() == 0 {
+        frame.render_widget(spinner::widget(state, size.height).block(block), size);
+        return;
+    }
+
     let items: Vec<Spans> = state
         .get_projects()
         .iter()

--- a/src/ui/render/top_list.rs
+++ b/src/ui/render/top_list.rs
@@ -3,8 +3,8 @@ use crate::state::{Menu, State};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
-    text::Span,
-    widgets::{Block, Borders},
+    text::{Span, Spans},
+    widgets::{Block, Borders, Paragraph},
 };
 
 const BLOCK_TITLE: &str = "Projects";
@@ -21,5 +21,13 @@ pub fn top_list(frame: &mut Frame, size: Rect, state: &State) {
                 styling::active_block_title_style(),
             ));
     }
-    frame.render_widget(block, size);
+    let items: Vec<Spans> = state
+        .get_projects()
+        .iter()
+        .map(|p| Spans::from(vec![Span::raw(p.name.to_owned())]))
+        .collect();
+    let list = Paragraph::new(items)
+        .style(styling::normal_list_item_style())
+        .block(block);
+    frame.render_widget(list, size);
 }


### PR DESCRIPTION
Populates the top list menu with projects for the active workspace. When a project is selected, a task list view is pushed to the view stack and given focus with a loading spinner rendered within the view until the associated tasks have been fetched. Once the relevant tasks have been retrieved, the view is redrawn with the new data.