### PR TITLE
Refactoring shortcuts menu state management

### DIFF
--- a/src/events/terminal.rs
+++ b/src/events/terminal.rs
@@ -99,7 +99,7 @@ impl Handler {
                         match state.current_menu() {
                             Menu::Status => (),
                             Menu::Shortcuts => {
-                                state.previous_shortcut();
+                                state.previous_shortcut_index();
                             }
                             Menu::TopList => {
                                 state.previous_top_list_item();
@@ -117,7 +117,7 @@ impl Handler {
                         match state.current_menu() {
                             Menu::Status => (),
                             Menu::Shortcuts => {
-                                state.next_shortcut();
+                                state.next_shortcut_index();
                             }
                             Menu::TopList => {
                                 state.next_top_list_item();
@@ -135,7 +135,7 @@ impl Handler {
                         match state.current_menu() {
                             Menu::Status => (),
                             Menu::Shortcuts => {
-                                state.select_current_shortcut();
+                                state.select_current_shortcut_index();
                             }
                             Menu::TopList => {
                                 state.select_current_top_list_item();

--- a/src/ui/render/shortcuts.rs
+++ b/src/ui/render/shortcuts.rs
@@ -1,9 +1,8 @@
 use super::Frame;
-use crate::state::{Focus, Menu, Shortcut, State};
+use crate::state::{Focus, Menu, State, SHORTCUTS};
 use crate::ui::widgets::styling;
 use tui::{
     layout::Rect,
-    style::Style,
     text::{Span, Spans},
     widgets::{Block, Borders, Paragraph},
 };
@@ -14,10 +13,6 @@ const BLOCK_TITLE: &str = "Shortcuts";
 ///
 pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
     let mut block = Block::default().title(BLOCK_TITLE).borders(Borders::ALL);
-
-    let mut my_tasks_style = Style::default();
-    let mut recently_modified_style = Style::default();
-    let mut recently_completed_style = Style::default();
 
     let mut list_item_style = styling::current_list_item_style();
     if *state.current_focus() == Focus::Menu && *state.current_menu() == Menu::Shortcuts {
@@ -30,29 +25,20 @@ pub fn shortcuts(frame: &mut Frame, size: Rect, state: &State) {
         list_item_style = styling::active_list_item_style();
     }
 
-    match state.current_shortcut() {
-        Shortcut::MyTasks => {
-            my_tasks_style = list_item_style;
-        }
-        Shortcut::RecentlyModified => {
-            recently_modified_style = list_item_style;
-        }
-        Shortcut::RecentlyCompleted => {
-            recently_completed_style = list_item_style;
-        }
-    };
+    let text: Vec<Spans> = SHORTCUTS
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let span;
+            if i == *state.current_shortcut_index() {
+                span = Span::styled(s.to_owned(), list_item_style);
+            } else {
+                span = Span::raw(s.to_owned());
+            }
+            Spans::from(vec![span])
+        })
+        .collect();
 
-    let text = vec![
-        Spans::from(vec![Span::styled("My Tasks", my_tasks_style)]),
-        Spans::from(vec![Span::styled(
-            "Recently Modified",
-            recently_modified_style,
-        )]),
-        Spans::from(vec![Span::styled(
-            "Recently Completed",
-            recently_completed_style,
-        )]),
-    ];
     let paragraph = Paragraph::new(text).block(block);
     frame.render_widget(paragraph, size);
 }


### PR DESCRIPTION
Eschewing an enum for an array, simplifying usage of the shortcuts menu state. Specifically, when rendering the shortcuts menu and determining which item to style as selected, the enum implementation required explicitly comparing every possible enum value with the current shortcut in state while the array implementation allows iterating over the possible shortcuts and comparing the index with the current shortcut index in state.